### PR TITLE
kafka lag probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,12 @@
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
-    "joi-extract-type": "^15.0.8"
+    "@types/node": "^18.11.11",
+    "joi-extract-type": "^15.0.8",
+    "prometheus-query": "^3.3.0",
+    "werelogs": "scality/werelogs"
+  },
+  "engines": {
+    "node": ">= 16"
   }
 }

--- a/src/probes/KafkaConsumerLagProbe.ts
+++ b/src/probes/KafkaConsumerLagProbe.ts
@@ -1,25 +1,56 @@
 import * as joi from '@hapi/joi';
+import 'joi-extract-type';
 
 import { Probe } from './Probe';
+import { PrometheusClient, prometheusClientConfigSchema } from './PrometheusClient';
+
+import { Logger } from 'werelogs';
+
+const log = new Logger('breakbeat:probe:kafkaConsumerLag');
 
 export const kafkaConsumerLagProbeSchema = joi.object({
     type: joi.string().valid('kafkaConsumerLag').required(),
+
+    prometheus: prometheusClientConfigSchema.required(),
+
+    wantTotalLagLessThan: joi.number().greater(0).required(),
+    averagedOverInterval: joi.string().regex(new RegExp('^\\d+[smhd]$')).optional(),
+    consumerGroupName: joi.string().required(),
+    topicName: joi.string().optional(),
 });
 
 export type KafkaConsumerLagProbeConfig = joi.extractType<typeof kafkaConsumerLagProbeSchema>;
 
 export class KafkaConsumerLagProbe implements Probe {
     config: KafkaConsumerLagProbeConfig;
+    lag: number;
+    prometheusClient: PrometheusClient;
 
     constructor(config: KafkaConsumerLagProbeConfig) {
+        const topic = config.topicName ? `,topic="${config.topicName}"` : '';
+        const q = `kafka_consumergroup_group_lag{
+            group="${config.consumerGroupName}"
+            ${topic}
+        }`;
+
+        this.prometheusClient = new PrometheusClient(
+            config.prometheus, q, config.averagedOverInterval);
         this.config = config;
+        this.lag = 0;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    check() {
+    async check() {
+        const v = await this.prometheusClient.instantQuery();
+        if (v != null) {
+            if (Number.isNaN(v)) {
+                log.warn('warning: ignoring received NaN value (interval too long for retention?)');
+                return;
+            }
+            this.lag = v;
+        }
     }
 
     get value() {
-        return false;
+        return this.lag < this.config.wantTotalLagLessThan;
     }
 }

--- a/src/probes/NoopProbe.ts
+++ b/src/probes/NoopProbe.ts
@@ -16,8 +16,8 @@ export class NoopProbe implements Probe {
         this.config = config;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    check() {
+    check(): Promise<void> {
+        return Promise.resolve();
     }
 
     get value() {

--- a/src/probes/Probe.ts
+++ b/src/probes/Probe.ts
@@ -1,4 +1,4 @@
 export interface Probe {
-    check(): void;
+    check(): Promise<void>;
     get value(): boolean;
 }

--- a/src/probes/PrometheusClient.ts
+++ b/src/probes/PrometheusClient.ts
@@ -1,0 +1,57 @@
+import * as joi from '@hapi/joi';
+import 'joi-extract-type';
+
+import { PrometheusDriver } from 'prometheus-query';
+import { Logger } from 'werelogs';
+
+const log = new Logger('breakbeat:prometheusClient');
+
+export const prometheusClientConfigSchema = joi.object({
+    endpoint: joi.string().uri({
+        scheme: ['http', 'https'],
+        allowRelative: false,
+    }).required(),
+    timeout: joi.number().optional(),
+});
+
+export type PrometheusClientConfig = joi.extractType<typeof prometheusClientConfigSchema>;
+
+type InstantResult = {
+    value: {
+        value: number,
+    },
+};
+
+export class PrometheusClient {
+    prom: PrometheusDriver;
+    q: string;
+
+    constructor(config: PrometheusClientConfig, q: string, interval?: string) {
+        this.prom = new PrometheusDriver({
+            endpoint: config.endpoint,
+            timeout:  config.timeout,
+        });
+
+        this.q = interval ?
+            `sum(avg_over_time(${q}[${interval}]))` :
+            `sum(${q})`;
+    }
+
+    async instantQuery(): Promise<number | null> {
+        try {
+            const res = await this.prom.instantQuery(this.q);
+
+            // res.result is an any[]
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const series: InstantResult[] = res.result;
+            if (series.length == 0) {
+                return null;
+            }
+
+            return series[0].value.value;
+        } catch (error: unknown) {
+            log.error('unable to query prometheus', { error });
+            return null;
+        }
+    }
+}

--- a/tests/unit/probes/index.spec.ts
+++ b/tests/unit/probes/index.spec.ts
@@ -22,6 +22,11 @@ describe('Probe', () => {
             test('should build a noop probe', () => {
                 const kcl = buildProbe({
                     type: 'kafkaConsumerLag',
+                    consumerGroupName: 'group',
+                    wantTotalLagLessThan: 15,
+                    prometheus: {
+                        endpoint: 'http://localhost:9090',
+                    },
                 });
 
                 expect(kcl).toBeInstanceOf(KafkaConsumerLagProbe);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,6 +1469,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
+"@types/node@^18.11.11":
+  version "18.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"
+  integrity sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==
+
 "@types/prettier@^2.1.5":
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
@@ -1684,6 +1689,13 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 babel-jest@^29.3.1:
   version "29.3.1"
@@ -2266,6 +2278,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -2331,6 +2348,11 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.14.8:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 foreground-child@^2.0.0:
   version "2.0.0"
@@ -3429,6 +3451,13 @@ process-on-spawn@^1.0.0:
   dependencies:
     fromentries "^1.2.0"
 
+prometheus-query@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/prometheus-query/-/prometheus-query-3.3.0.tgz#5267e2ba8b24d5f80838f82c4ec08c3862d49f1b"
+  integrity sha512-jsS95vcu1an0+M1IR9sDTPFvuKzezoiLnWDSIgam2S3rBB2Yk45HteBfsHXpo9Vxn+rASQgGUtnWbsjRILXHlA==
+  dependencies:
+    axios "^0.26.1"
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -3571,6 +3600,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+safe-json-stringify@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
 semver@7.x, semver@^7.3.5, semver@^7.3.7:
   version "7.3.8"
@@ -3896,6 +3930,13 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+werelogs@scality/werelogs:
+  version "8.1.2"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/c9952528699978e4b09164c67922b4fbcfd4654f"
+  dependencies:
+    fast-safe-stringify "^2.1.1"
+    safe-json-stringify "^1.2.0"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Adds a probe type that sums lag over all partitions consumed by a group (optionally narrowed by topic) and evaluates to false if lag is greater than some expected value.

Example:
```js
{
    type: 'kafkaConsumerLag',
    consumerGroupName: 'group',
    wantTotalLagLessThan: 15,
    prometheus: {
        endpoint: 'http://localhost:9090',
    },
}
```