### PR TITLE
Prometheus query probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breakbeat",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Overload Protection",
   "main": "lib/index.js",
   "repository": "https://github.com/scality/breakbeat",

--- a/src/probes/PrometheusQueryProbe.ts
+++ b/src/probes/PrometheusQueryProbe.ts
@@ -1,0 +1,51 @@
+import * as joi from '@hapi/joi';
+import 'joi-extract-type';
+
+import { Probe } from './Probe';
+import { PrometheusClient, prometheusClientConfigSchema } from './PrometheusClient';
+
+import { Logger } from 'werelogs';
+
+const log = new Logger('breakbeat:probe:prometheusQuery');
+
+export const prometheusQueryProbeSchema = joi.object({
+    type: joi.string().valid('prometheusQuery').required(),
+
+    prometheus: prometheusClientConfigSchema.required(),
+
+    query: joi.string().required(),
+    threshold: joi.number().required(),
+    averagedOverInterval: joi.string().regex(new RegExp('^\\d+[smhd]$')).optional(),
+});
+
+export type PrometheusQueryProbeConfig = joi.extractType<typeof prometheusQueryProbeSchema>;
+
+export class PrometheusQueryProbe implements Probe {
+    config: PrometheusQueryProbeConfig;
+    threshold: number;
+    prometheusClient: PrometheusClient;
+    observed: number;
+
+    constructor(config: PrometheusQueryProbeConfig) {
+        this.prometheusClient = new PrometheusClient(
+            config.prometheus, config.query, config.averagedOverInterval);
+        this.config = config;
+        this.threshold = 0;
+        this.observed = 0;
+    }
+
+    async check() {
+        const v = await this.prometheusClient.instantQuery();
+        if (v != null) {
+            if (Number.isNaN(v)) {
+                log.warn('warning: ignoring received NaN value (interval too long for retention?)');
+                return;
+            }
+            this.observed = v;
+        }
+    }
+
+    get value() {
+        return this.observed < this.config.threshold;
+    }
+}

--- a/src/probes/index.ts
+++ b/src/probes/index.ts
@@ -3,11 +3,13 @@ import 'joi-extract-type';
 
 import { NoopProbe, noopProbeSchema } from './NoopProbe';
 import { KafkaConsumerLagProbe, kafkaConsumerLagProbeSchema } from './KafkaConsumerLagProbe';
+import { PrometheusQueryProbe, prometheusQueryProbeSchema } from './PrometheusQueryProbe';
 import { Probe } from './Probe';
 
 const probeSchema = joi.alternatives().try(
     noopProbeSchema.required(),
     kafkaConsumerLagProbeSchema.required(),
+    prometheusQueryProbeSchema.required(),
 );
 
 export type ProbeConfig = joi.extractType<typeof probeSchema>;
@@ -19,6 +21,8 @@ function buildProbe(probeConfig: ProbeConfig): Probe {
         return new NoopProbe(probeConfig);
     case 'kafkaConsumerLag':
         return new KafkaConsumerLagProbe(probeConfig);
+    case 'prometheusQuery':
+        return new PrometheusQueryProbe(probeConfig);
     }
 
     // not really dead code for transpiled uses

--- a/tests/unit/probes/index.spec.ts
+++ b/tests/unit/probes/index.spec.ts
@@ -4,6 +4,7 @@ import { buildProbe } from '../../../src/probes';
 
 import { NoopProbe } from '../../../src/probes/NoopProbe';
 import { KafkaConsumerLagProbe } from '../../../src/probes/KafkaConsumerLagProbe';
+import { PrometheusQueryProbe } from '../../../src/probes/PrometheusQueryProbe';
 
 describe('Probe', () => {
     describe('buildProbe', () => {
@@ -19,7 +20,7 @@ describe('Probe', () => {
         });
 
         describe('kafkaConsumerLag', () => {
-            test('should build a noop probe', () => {
+            test('should build a kafkaConsumerLag probe', () => {
                 const kcl = buildProbe({
                     type: 'kafkaConsumerLag',
                     consumerGroupName: 'group',
@@ -30,6 +31,22 @@ describe('Probe', () => {
                 });
 
                 expect(kcl).toBeInstanceOf(KafkaConsumerLagProbe);
+            });
+        });
+
+        describe('prometheusQuery', () => {
+            test('should build a prometheusQuery probe', () => {
+                const kcl = buildProbe({
+                    type: 'prometheusQuery',
+                    query: 'mem{process="node"}',
+                    threshold: 15,
+                    prometheus: {
+                        endpoint: 'http://localhost:9090',
+                        timeout: 10000,
+                    },
+                });
+
+                expect(kcl).toBeInstanceOf(PrometheusQueryProbe);
             });
         });
 


### PR DESCRIPTION
Implements a generic prometheus query probe and refactors the kafka lag probe on top of it.

```js
{
    type: 'prometheusQuery',
    query: 'mem{process="node"}',
    threshold: 15,
    prometheus: {
        endpoint: 'http://localhost:9090',
        timeout: 10000,
    },
}
```