### PR TITLE
Fix import from nodejs modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,8 @@ module.exports = {
     root: true,
     ignorePatterns: [
         '*.js',
+        '*.d.ts',
+        '*.spec.ts',
     ],
     rules: {
         'strict': [2, 'global'],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "tsc --strict",
     "coverage": "nyc --clean jest --coverage --detectOpenHandles",
     "lint": "eslint .",
+    "postinstall": "yarn build",
+    "prepack": "yarn build",
     "prepare": "yarn build",
     "test": "jest --detectOpenHandles",
     "test:watch": "jest --watch"
@@ -26,14 +28,14 @@
     "jest": "^29.3.1",
     "nyc": "^15.1.0",
     "ts-jest": "^29.0.3",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.9.3"
+    "ts-node": "^10.9.1"
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "@types/node": "^18.11.11",
     "joi-extract-type": "^15.0.8",
     "prometheus-query": "^3.3.0",
+    "typescript": "^4.9.5",
     "werelogs": "scality/werelogs"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breakbeat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Overload Protection",
   "main": "lib/index.js",
   "repository": "https://github.com/scality/breakbeat",

--- a/src/probes/KafkaConsumerLagProbe.ts
+++ b/src/probes/KafkaConsumerLagProbe.ts
@@ -2,11 +2,7 @@ import * as joi from '@hapi/joi';
 import 'joi-extract-type';
 
 import { PrometheusQueryProbe } from './PrometheusQueryProbe';
-import { PrometheusClient, prometheusClientConfigSchema } from './PrometheusClient';
-
-import { Logger } from 'werelogs';
-
-const log = new Logger('breakbeat:probe:kafkaConsumerLag');
+import { prometheusClientConfigSchema } from './PrometheusClient';
 
 export const kafkaConsumerLagProbeSchema = joi.object({
     type: joi.string().valid('kafkaConsumerLag').required(),
@@ -30,7 +26,7 @@ export class KafkaConsumerLagProbe extends PrometheusQueryProbe {
         }`;
 
         super({
-            type: "prometheusQuery",
+            type: 'prometheusQuery',
             prometheus: config.prometheus,
             query: q,
             threshold: config.wantTotalLagLessThan,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,10 @@
     "include": [
         "src/*.ts",
         "src/*/*.ts",
-        "tests/**/*.ts",
-        "index.ts",
+        "index.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "tests"
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,10 +3862,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
For some reason being imported from a pure-nodejs module was not calling the build step (it did before), so going belt and suspenders to make sure nothing fails to compile silently.